### PR TITLE
Updating license comments

### DIFF
--- a/hrmanifest.xsd
+++ b/hrmanifest.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright © 2013-2025 Kuali, Inc. - All Rights Reserved -->
 <xs:schema  xmlns:xs="http://www.w3.org/2001/XMLSchema"
      targetNamespace="https://github.com/rSmart/ce-tech-docs/tree/master/v2_0"
                xmlns="https://github.com/rSmart/ce-tech-docs/tree/master/v2_0"

--- a/v1_0/hrmanifest.xsd
+++ b/v1_0/hrmanifest.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright © 2013-2025 Kuali, Inc. - All Rights Reserved -->
 <xs:schema  xmlns:xs="http://www.w3.org/2001/XMLSchema"
      targetNamespace="https://github.com/rSmart/ce-tech-docs/tree/master/v1_0"
                xmlns="https://github.com/rSmart/ce-tech-docs/tree/master/v1_0"

--- a/v2_0/hrmanifest.xsd
+++ b/v2_0/hrmanifest.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright © 2013-2025 Kuali, Inc. - All Rights Reserved -->
 <xs:schema  xmlns:xs="http://www.w3.org/2001/XMLSchema"
      targetNamespace="https://github.com/rSmart/ce-tech-docs/tree/master/v2_0"
                xmlns="https://github.com/rSmart/ce-tech-docs/tree/master/v2_0"

--- a/v3_0/hrmanifest.xsd
+++ b/v3_0/hrmanifest.xsd
@@ -1,24 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    The Kuali Financial System, a comprehensive financial management system for higher education.
-
-    Copyright 2005-2025 Kuali, Inc.
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
--->
+<!-- Copyright © 2013-2025 Kuali, Inc. - All Rights Reserved -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="https://github.com/KualiCo/ce-tech-docs/tree/master/v3_0"
            xmlns="https://github.com/KualiCo/ce-tech-docs/tree/master/v3_0"

--- a/v3_0/v2-to-v3.xslt
+++ b/v3_0/v2-to-v3.xslt
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!-- Copyright © 2013-2025 Kuali, Inc. - All Rights Reserved -->
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:g="https://github.com/rSmart/ce-tech-docs/tree/master/v2_0"


### PR DESCRIPTION
## Summary
- Updated copyright year range to 2013-2025 in all source files
- Replaced AGPL license block in v3_0/hrmanifest.xsd with single-line copyright header
- Added copyright headers to 4 XSD schema files and 1 XSLT file
- Total of 5 files updated

## Changes
All source code files now have the updated copyright header:
```
<!-- Copyright © 2013-2025 Kuali, Inc. - All Rights Reserved -->
```

## Files Updated
- hrmanifest.xsd (root)
- v1_0/hrmanifest.xsd
- v2_0/hrmanifest.xsd
- v3_0/hrmanifest.xsd (replaced multi-line AGPL license block)
- v3_0/v2-to-v3.xslt

🤖 Generated with [Claude Code](https://claude.com/claude-code)